### PR TITLE
use official steam runtime setup script

### DIFF
--- a/launch/vive.launch
+++ b/launch/vive.launch
@@ -1,14 +1,9 @@
 <?xml version="1.0"?>
 <launch>
-  <env name="OPENVR" value="$(env HOME)/libraries/openvr"/>
-  <env name="STEAM" value="$(env HOME)/.local/share/Steam"/>
-  <env name="STEAMVR" value="$(env HOME)/.steam/steam/steamapps/common/SteamVR"/>
-
-  <env name="LD_LIBRARY_PATH" value="$(env LD_LIBRARY_PATH):$(env HOME)/libraries/openvr/lib/linux64:$(env HOME)/.local/share/Steam/ubuntu12_32/steam-runtime/amd64/lib/x86_64-linux-gnu:$(env HOME)/.steam/steam/steamapps/common/SteamVR/bin/linux64:$(env HOME)/.steam/steam/steamapps/common/SteamVR/drivers/lighthouse/bin/linux64"/>
 
   <rosparam param="/vive/world_offset">[0, 0, 2.265]</rosparam>
   <rosparam param="/vive/world_yaw">0.0</rosparam>
 
-  <node name="vive_node" pkg="vive_ros" type="vive_node" output="screen" required="true"/>
+  <node name="vive_node" pkg="vive_ros" type="vive_node" launch-prefix="$(env HOME)/.steam/ubuntu12_32/steam-runtime/run.sh" output="screen" required="true"/>
 
 </launch>


### PR DESCRIPTION
This will be more correct way to go along with steam runtime.
But, I haven't find clear way to start server_vr.launch or check_vr.launch as the same way.
I'm now starting steamVR service from official steam GUI.
(I only know `pHMD_ = vr::VR_Init( &eError, vr::VRApplication_Scene );` calls SteamVR service automatically)