### PR TITLE
Auto select steam runtime script path

### DIFF
--- a/launch/vive.launch
+++ b/launch/vive.launch
@@ -1,14 +1,10 @@
 <?xml version="1.0"?>
 <launch>
-  <env name="OPENVR" value="$(env HOME)/libraries/openvr"/>
-  <env name="STEAM" value="$(env HOME)/.local/share/Steam"/>
-  <env name="STEAMVR" value="$(env HOME)/.steam/steam/steamapps/common/SteamVR"/>
-
-  <env name="LD_LIBRARY_PATH" value="$(env LD_LIBRARY_PATH):$(env HOME)/libraries/openvr/lib/linux64:$(env HOME)/.local/share/Steam/ubuntu12_32/steam-runtime/amd64/lib/x86_64-linux-gnu:$(env HOME)/.steam/steam/steamapps/common/SteamVR/bin/linux64:$(env HOME)/.steam/steam/steamapps/common/SteamVR/drivers/lighthouse/bin/linux64"/>
 
   <rosparam param="/vive/world_offset">[0, 0, 2.265]</rosparam>
   <rosparam param="/vive/world_yaw">0.0</rosparam>
 
-  <node name="vive_node" pkg="vive_ros" type="vive_node" output="screen" required="true"/>
+  <node name="vive_node" pkg="vive_ros" type="vive_node" launch-prefix="$(find vive_ros)/scripts/find_steam_runtime.sh" output="screen" required="true"/>
 
 </launch>
+

--- a/scripts/find_steam_runtime.sh
+++ b/scripts/find_steam_runtime.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+candidate_1=${HOME}/.steam/ubuntu12_32/steam-runtime/run.sh
+candidate_2=${HOME}/.steam/steam/ubuntu12_32/steam-runtime/run.sh
+
+if [ -e $candidate_1 ]; then
+    echo "runtime setup script found on $candidate_1"
+    exec $candidate_1 "$@"
+    
+elif [ -e $candidate_2 ]; then
+    echo "runtime setup script found on $candidate_2"
+    exec $candidate_2 "$@"
+
+else
+    echo "\e[31m [ERROR] steam runtime setup script not found !! \e[m"
+    exit 1
+fi


### PR DESCRIPTION
https://github.com/robosavvy/vive_ros/pull/21#issuecomment-484118727

How about this?
I think we can run vive_node on both steam environment.
Newly added find_steam_runtime.sh will check the existence of run.sh and use it.